### PR TITLE
tableOutput() and renderTable()

### DIFF
--- a/vignettes/datamods.Rmd
+++ b/vignettes/datamods.Rmd
@@ -90,7 +90,7 @@ ui <- fluidPage(
     column(
       width = 8,
       tags$b("Imported data:"),
-      verbatimTextOutput(outputId = "result")
+      tableOutput(outputId = "result")
     )
   )
 )
@@ -99,7 +99,7 @@ server <- function(input, output, session) {
   
   imported <- import_file_server("myid") #> this is the server module
   
-  output$result <- renderPrint({
+  output$result <- renderTable({
     imported$data()
   })
   


### PR DESCRIPTION
Hi, great package ! 

I think it would be better to showcase the example using the tableOutput and renderTable functions instead of verbatimTextOutput and renderPrint. 


Best.