### PR TITLE
Explicitly read json format from URL

### DIFF
--- a/R/import-url.R
+++ b/R/import-url.R
@@ -100,7 +100,7 @@ import_url_server <- function(id,
     observeEvent(input$link, {
       req(input$link)
 
-      imported <- try(rio::import(input$link), silent = TRUE)
+      imported <- try(rio::import(input$link, format = "json"), silent = TRUE)
 
       if (inherits(imported, "try-error") || NROW(imported) < 1) {
         toggle_widget(inputId = "confirm", enable = FALSE)


### PR DESCRIPTION
To avoid errors " Unrecognized file format. Try specifying with the format argument."