### PR TITLE
Make `edit_data` accept reactable options

### DIFF
--- a/R/edit-data-utils.R
+++ b/R/edit-data-utils.R
@@ -59,7 +59,7 @@ edit_modal <- function(default = list(),
       data = data,
       colnames = colnames,
       var_mandatory = var_mandatory,
-      position_var_edit =  position_var_edit,
+      position_var_edit = position_var_edit,
       session = session
     ),
     actionButton(
@@ -172,34 +172,53 @@ edit_input_form <- function(default = list(),
 #'
 #' @param data `data.frame` to use
 #' @param colnames `data.frame` column names
+#' @param options Arguments passed to [reactable::reactable()].
 #'
 #' @return the `data.frame` in reactable format
 #' @noRd
 #'
 #' @importFrom reactable reactable colDef
 #'
-table_display <- function(data, colnames = NULL) {
-  cols <- list()
-  for (i in seq_along(data)) {
-    cols[[names(data)[i]]] <- colDef(name = colnames[i])
+table_display <- function(data, colnames = NULL, options = NULL) {
+  if (is.null(options)) {
+    options <- list()
   }
+
+  options <- modifyList(x = options, val = list(
+    bordered = TRUE,
+    compact = TRUE,
+    striped = TRUE
+  ))
+
+  cols <- list()
+  if (is.null(options$columns)) {
+    options$columns <- list()
+  }
+
   if (all(is.na(data$.datamods_edit_update))) {
-    cols$.datamods_edit_update = colDef(show = FALSE)
+    cols$.datamods_edit_update <- colDef(show = FALSE)
   } else {
-    cols$.datamods_edit_update = col_def_update()
+    cols$.datamods_edit_update <- col_def_update()
   }
 
   if (all(is.na(data$.datamods_edit_delete))) {
-    cols$.datamods_edit_delete = colDef(show = FALSE)
+    cols$.datamods_edit_delete <- colDef(show = FALSE)
   } else {
-    cols$.datamods_edit_delete = col_def_delete()
+    cols$.datamods_edit_delete <- col_def_delete()
   }
 
   cols$.datamods_id <- colDef(show = FALSE)
-  reactable(
-    data = data,
-    columns = cols
-  )
+
+  options$data <- data
+  for (i in seq_along(colnames)) {
+    data.table::setnames(x = data, old = names(data)[i], new = colnames[i])
+  }
+
+  options$columns <- modifyList(x = options$columns, val = cols)
+
+  table <- rlang::exec(reactable::reactable, !!!options)
+
+  return(table)
 }
 
 

--- a/R/edit-data.R
+++ b/R/edit-data.R
@@ -55,6 +55,7 @@ edit_data_ui <- function(id) {
 #' @param var_edit vector of `character` which allows to choose the names of the editable columns
 #' @param var_mandatory vector of `character` which allows to choose obligatory fields to fill
 #' @param return_class Class of returned data: `data.frame`, `data.table`, `tbl_df` (tibble) or `raw`.
+#' @param options Arguments passed to [reactable::reactable()].
 #'
 #' @return the edited `data.frame` in reactable format with the user modifications
 #'
@@ -80,12 +81,12 @@ edit_data_server <- function(id,
                              file_name_export = "data",
                              var_edit = NULL,
                              var_mandatory = NULL,
-                             return_class = c("data.frame", "data.table", "tbl_df", "raw")) {
+                             return_class = c("data.frame", "data.table", "tbl_df", "raw"),
+                             options = NULL) {
   return_class <- match.arg(return_class)
   moduleServer(
     id,
     function(input, output, session) {
-
       ns <- session$ns
 
       data_rv <- reactiveValues(data = NULL, colnames = NULL, mandatory = NULL, edit = NULL)
@@ -94,12 +95,15 @@ edit_data_server <- function(id,
       data_init_r <- eventReactive(data_r(), {
         req(data_r())
         data <- data_r()
-        if (is.reactive(var_mandatory))
+        if (is.reactive(var_mandatory)) {
           var_mandatory <- var_mandatory()
-        if (is.reactive(var_edit))
+        }
+        if (is.reactive(var_edit)) {
           var_edit <- var_edit()
-        if (is.null(var_edit))
+        }
+        if (is.null(var_edit)) {
           var_edit <- names(data)
+        }
         data <- as.data.table(data)
         data_rv$colnames <- copy(colnames(data))
         if (!isTRUE(identical(x = seq_along(data), y = integer(0)))) {
@@ -146,7 +150,8 @@ edit_data_server <- function(id,
         data <- req(data_init_r())
         table_display(
           data = data,
-          colnames = data_rv$colnames
+          colnames = data_rv$colnames,
+          options = options
         )
       })
 
@@ -407,4 +412,3 @@ edit_data_server <- function(id,
     }
   )
 }
-

--- a/tests/testthat/test-edit-data.R
+++ b/tests/testthat/test-edit-data.R
@@ -54,6 +54,27 @@ test_that("confirmation_window works", {
   expect_is(confirmation_window(inputId = "input", title = "titre"), "shiny.tag")
 })
 
+test_that("reactable options works",{
 
+  mydata <- iris
+  mydata <- as.data.table(mydata)
+
+  mydata[, .datamods_edit_update := as.character(seq_len(.N))]
+  mydata[, .datamods_edit_delete := as.character(seq_len(.N))]
+  mydata[, .datamods_id := seq_len(.N)]
+
+  table <-
+    table_display(mydata, colnames = NULL,
+                options = list(columns = list(Species = colDef(name = "Spec.")),
+                               searchable = TRUE,
+                               pagination = FALSE,
+                               height = 500))
+
+  expect_true(table$x$tag$attribs$searchable)
+  expect_false(table$x$tag$attribs$pagination)
+  expect_equal(table$height, "500px")
+  expect_equal(table$x$tag$attribs$columns[[5]]$name, "Spec.")
+
+})
 
 


### PR DESCRIPTION
I tried to implement reactable options similar to `show_data()` as it was mentioned in #77.

Test with following shiny app:

<details>

```r
devtools::load_all()
library(shiny)
# library(datamods)
library(bslib)

ui <- fluidPage(
  theme = bs_theme(
    version = 5
  ),
  tags$h2(i18n("Edit data"), align = "center"),
  edit_data_ui(id = "id"),
  verbatimTextOutput("result")
)


server <- function(input, output, session) {
  edited_r <- edit_data_server(
    id = "id",
    data_r = reactive(demo_edit),
    add = TRUE,
    update = TRUE,
    delete = TRUE,
    download_csv = TRUE,
    download_excel = TRUE,
    file_name_export = "datas",
    # var_edit = c("name", "job", "credit_card_provider", "credit_card_security_code"),
    var_mandatory = c("name", "job"),
    options = list(
      pagination = FALSE,
      searchable = TRUE,
      height = 400,
      columns = list(
        name = colDef(width = 200),
        job = colDef(name = "Job", sortable = TRUE)
      )
    )
  )

  output$result <- renderPrint({
    str(edited_r())
  })
}

if (interactive()) {
  shinyApp(ui, server)
}
```

</details>

![image](https://github.com/dreamRs/datamods/assets/34234913/19594c66-f773-4c7a-8c50-926f0b6d2cdd)
